### PR TITLE
 make "Now Playing" work

### DIFF
--- a/iOS-RadioPlayer-2/AppDelegate.m
+++ b/iOS-RadioPlayer-2/AppDelegate.m
@@ -28,6 +28,11 @@
     [player whenAvailable:^{
         NSLog(@"Available!");
 
+        // By default, the player sets the `AVAudioSessionCategoryOptions` to `AVAudioSessionCategoryOptionMixWithOthers`, which
+        // prevents us from becoming the 'Now Playing' app in the lock screen. The following removes that option, so this
+        // app will show up and be controllable on the lock screen.
+        [player setAVAudioSessionCategory:AVAudioSessionCategoryPlayback mode:AVAudioSessionModeDefault options:  0 ];
+
         player.secondsOfCrossfade = 0.0;
 
     } notAvailable:^{


### PR DESCRIPTION
This app plays music fine while backgrounded, but it wasn't appearing in the `Now Playing` controls on the lock screen. This patch fixes that.
